### PR TITLE
hotfix: invalid tokenexpiry

### DIFF
--- a/src/helpers/TokenHelper.ts
+++ b/src/helpers/TokenHelper.ts
@@ -37,9 +37,12 @@ export function getTokenFromStorage(): Token {
 }
 
 export function isTokenExpired(tokenEpochTimestamp: number): boolean {
-    const tokenExpirationTime = tokenEpochTimestamp * 1000;
-    const currentTimestamp = new Date().getTime();
-    return currentTimestamp > tokenExpirationTime;
+  // If the expiry is somewhere around the year 33658 assume migration from old frontend and always set expired to force re-login.
+  if (tokenEpochTimestamp > 1000000000000) return true;
+
+  const tokenExpirationTime = tokenEpochTimestamp * 1000;
+  const currentTimestamp = new Date().getTime();
+  return currentTimestamp > tokenExpirationTime;
 }
 
 /**


### PR DESCRIPTION
The old frontend stores the token expiry to be in millisecond, while the new frontend parses those milliseconds as seconds, making it seems like most tokens are expired in the year 56382. Hotfix regards all tokens that expire later than the year 33658 as invalid.

Note: the frontend will break in the year 33658
Second note: Let's just go back to taking the expiry from the jwt token instead of storing it seperatly 